### PR TITLE
Fix hospital capacity scraper

### DIFF
--- a/hospital-capacity/scrape.py
+++ b/hospital-capacity/scrape.py
@@ -1,6 +1,7 @@
 """
 Download patient capacity data from the U.S. Department of Health and Human Services.
 """
+import csv
 import io
 import pathlib
 import requests
@@ -10,14 +11,52 @@ import pandas as pd
 THIS_DIR = pathlib.Path(__file__).parent.absolute()
 DATA_DIR = THIS_DIR / "data"
 
+# Constants
+DEFAULT_LIMIT = 5000
+
+def get(url, **kwargs):
+    """
+    Read data from the requested resource.
+    """
+    params = {}
+    params.update(kwargs)
+
+    response = requests.get(url, params=params, stream=True)
+    response.raise_for_status()
+    
+    csv_stream = io.StringIO(response.text)
+    return list(csv.DictReader(csv_stream))
+
+
+def get_all(url, **kwargs):
+    """
+    Read data from the requested resource, paginating over all results.
+    Returns a generator.
+    """
+    params = {}
+    params.update(kwargs)
+    if "offset" not in params:
+        params["$offset"] = 0
+    limit = params.get("limit", DEFAULT_LIMIT)
+    params["$limit"] = limit
+
+    while True:
+        response = get(url, **params)
+
+        for item in response:
+            yield item
+
+        if len(response) < limit:
+            return
+        params["$offset"] += limit
+
+
 def main():
     """
-    Download the metadata endpoint and find the CSV.
+    Download the CSV.
     """
-    url = "https://healthdata.gov/api/views/anag-cw7u/rows.csv?accessType=DOWNLOAD"
-    r = requests.get(url)
-    data = r.content.decode("utf-8")
-    df = pd.read_csv(io.StringIO(data), dtype={"fips_code": str, "zip": str})
+    results = get_all("https://healthdata.gov/resource/anag-cw7u.csv", state="CA")
+    df = pd.DataFrame(results)
     df.to_csv(DATA_DIR / "latest.csv", index=False)
 
 

--- a/hospital-capacity/scrape.py
+++ b/hospital-capacity/scrape.py
@@ -25,7 +25,7 @@ def get(url, **kwargs):
     response.raise_for_status()
     
     csv_stream = io.StringIO(response.text)
-    return list(csv.DictReader(csv_stream))
+    return csv.DictReader(csv_stream)
 
 
 def get_all(url, **kwargs):
@@ -43,10 +43,12 @@ def get_all(url, **kwargs):
     while True:
         response = get(url, **params)
 
+        count = 0
         for item in response:
+            count += 1
             yield item
 
-        if len(response) < limit:
+        if count < limit:
             return
         params["$offset"] += limit
 


### PR DESCRIPTION
The hospital capacity scraper can no longer successfully commit the data file because it has become too large for GitHub. However... we don't need all that data anyway, because it 1) includes every single state, not just California, and 2) the data source has historical built-in (a row for each hospital and each week) so we're not really backing up anything here.

In effort to just get this to work again, I've 1) moved from the bulk CSV URL (that cannot be filtered) to the normal API URL, 2) filtered out every state but California, 3) implemented a light wrapper around pagination so we don't make Socrata mad but can still get the data pretty quickly.

Will be hard to know if this breaks other aspects of things until they're tested.